### PR TITLE
Use -no-🥧 to avoid PIE warnings for Standard ML

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,20 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # 2. apt install all the things
 RUN apt-get update && apt-get install -yqq --no-install-recommends\
   # build-essential includes `make`, `gcc` and `g++`
-  build-essential\
+  build-essential git\
   default-jdk\
   golang\
   nodejs\
   php-cli\
-  polyml libpolyml-dev\
   python3\
   ruby\
   rustc\
-  && \
+  &&\
+  # build polyml from source
+  git clone https://github.com/polyml/polyml.git /tmp/polyml && cd /tmp/polyml && \
+  CFLAGS=-no-pie ./configure --prefix=/usr && make && make compiler && make install && \
+  cd / && rm -rf /tmp/polyml && \
   # Cleanup what we don't need
-  rm -rf /var/lib/apt/lists/* \ 
+  rm -rf /var/lib/apt/lists/* \
   && \
-  apt-get autoremove \
-  ;
-
+  apt-get autoremove -yqq git

--- a/languages/sml.sh
+++ b/languages/sml.sh
@@ -10,7 +10,7 @@ SOLUTION="$3"
 OUT="$(mktemp)"
 trap 'rm -f "$OUT"' EXIT
 
-polyc "$SOLUTION" -o "$OUT" 2> /dev/null
+polyc "$SOLUTION" -o "$OUT"
 
 start=$(($(date +%s%N)/1000000))
 cat $INPUT | $OUT | diff - $OUTPUT


### PR DESCRIPTION
Properly resolves #23 instead of hacking around a warning.

You may want to flip the Docker commands around to save time, e.g. like

```Dockerfile
RUN apt-get update && apt-get install -yqq --no-install-recommends \
  build-essential git

RUN git clone https://github.com/polyml/polyml.git /tmp/polyml && cd /tmp/polyml && \
  CFLAGS=-no-pie ./configure --prefix=/usr && make && make compiler && make install && \
  cd / && rm -rf /tmp/polyml

RUN apt-get install -yqq --no-install-recommends \
  default-jdk \
# ...
```

But it kinda depends on how resistant you are to big images. It's also possible to use `--squash` and experimental mode... but I'm guessing most people won't have it enabled and thus it probably sets the bar to add ones own solution too high.