### PR TITLE
Add pipefail to all shell scripts

### DIFF
--- a/days/day-00-example/test.sh
+++ b/days/day-00-example/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 D=$(dirname $(realpath $0))
 

--- a/days/day-01/test.sh
+++ b/days/day-01/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 D=$(dirname $(realpath $0))
 

--- a/days/day-02/test.sh
+++ b/days/day-02/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 D=$(dirname $(realpath $0))
 

--- a/days/day-03/test.sh
+++ b/days/day-03/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 D=$(dirname $(realpath $0))
 

--- a/days/day-04/test.sh
+++ b/days/day-04/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-05/test.sh
+++ b/days/day-05/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-06/test.sh
+++ b/days/day-06/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-07/test.sh
+++ b/days/day-07/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-08/test.sh
+++ b/days/day-08/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-09/test.sh
+++ b/days/day-09/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-10/test.sh
+++ b/days/day-10/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-11/test.sh
+++ b/days/day-11/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-12/test.sh
+++ b/days/day-12/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-13/test.sh
+++ b/days/day-13/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-14/test.sh
+++ b/days/day-14/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-15/test.sh
+++ b/days/day-15/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-16/test.sh
+++ b/days/day-16/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-17/test.sh
+++ b/days/day-17/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-18/test.sh
+++ b/days/day-18/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-19/test.sh
+++ b/days/day-19/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-20/test.sh
+++ b/days/day-20/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-21/test.sh
+++ b/days/day-21/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-22/test.sh
+++ b/days/day-22/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-23/test.sh
+++ b/days/day-23/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-24/test.sh
+++ b/days/day-24/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/days/day-25/test.sh
+++ b/days/day-25/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/languages/bash.sh
+++ b/languages/bash.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/bash.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/bash.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.bash

--- a/languages/c.sh
+++ b/languages/c.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/c.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/c.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.c

--- a/languages/cpp.sh
+++ b/languages/cpp.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/cpp.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/cpp.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.cpp

--- a/languages/go.sh
+++ b/languages/go.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/go.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/go.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.go

--- a/languages/java.sh
+++ b/languages/java.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/java.sh INPUT                 OUTPUT                 SOLUTION_DIR          JAVA_CLASSNAME
 # Example: ./languages/java.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions Example

--- a/languages/node.sh
+++ b/languages/node.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/node.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/node.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.js

--- a/languages/php.sh
+++ b/languages/php.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/php.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/php.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.php

--- a/languages/python.sh
+++ b/languages/python.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/python.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/python.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.py

--- a/languages/ruby.sh
+++ b/languages/ruby.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/ruby.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/ruby.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.rb

--- a/languages/rust.sh
+++ b/languages/rust.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 # Usage:   ./languages/rs.sh INPUT                 OUTPUT                 SOLUTION
 # Example: ./languages/rs.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.rs

--- a/scripts/make-folders.sh
+++ b/scripts/make-folders.sh
@@ -25,7 +25,7 @@ OUTPUT
 
     cat > "./$DAY/test.sh" << 'TEST'
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 DIR=$(dirname $(realpath $0))
 

--- a/scripts/print-test.sh
+++ b/scripts/print-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 CMD="$1"
 TIME="$2ms"

--- a/scripts/print-versions.sh
+++ b/scripts/print-versions.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 echo "$ uname -a"
 uname -a


### PR DESCRIPTION
Because fail fast.

When a program fails, it may hang the script, if it does not close the pipe to `diff`
```
cat input.txt | ./program  | diff - output.txt
```
This actually happened when testing the `zig` compiler, and we did not understand why. 

Please review @Avokadoen :pray: 