### PR TITLE
Upgrade nodejs v12 -> v15 by installing from nodesource

### DIFF
--- a/.github/workflows/day-00-example.yaml
+++ b/.github/workflows/day-00-example.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-01.yaml
+++ b/.github/workflows/day-01.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-02.yaml
+++ b/.github/workflows/day-02.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-03.yaml
+++ b/.github/workflows/day-03.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-04.yaml
+++ b/.github/workflows/day-04.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-05.yaml
+++ b/.github/workflows/day-05.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-06.yaml
+++ b/.github/workflows/day-06.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-07.yaml
+++ b/.github/workflows/day-07.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-08.yaml
+++ b/.github/workflows/day-08.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-09.yaml
+++ b/.github/workflows/day-09.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-10.yaml
+++ b/.github/workflows/day-10.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-11.yaml
+++ b/.github/workflows/day-11.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-12.yaml
+++ b/.github/workflows/day-12.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-13.yaml
+++ b/.github/workflows/day-13.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-14.yaml
+++ b/.github/workflows/day-14.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-15.yaml
+++ b/.github/workflows/day-15.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-16.yaml
+++ b/.github/workflows/day-16.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-17.yaml
+++ b/.github/workflows/day-17.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-18.yaml
+++ b/.github/workflows/day-18.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-19.yaml
+++ b/.github/workflows/day-19.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-20.yaml
+++ b/.github/workflows/day-20.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-21.yaml
+++ b/.github/workflows/day-21.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-22.yaml
+++ b/.github/workflows/day-22.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-23.yaml
+++ b/.github/workflows/day-23.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-24.yaml
+++ b/.github/workflows/day-24.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/.github/workflows/day-25.yaml
+++ b/.github/workflows/day-25.yaml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: "jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
+      image: "jonasjso/adventofcode2020:2020-12-05-with-node15"
     steps:
       - uses: actions/checkout@v2
       - name: make versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # 2. Build things from source first, so get build deps installed
 RUN apt-get update && apt-get install -yqq --no-install-recommends\
   # build-essential includes `make`, `gcc` and `g++`
-  build-essential git wget ca-certificates
+  build-essential git wget ca-certificates curl
 
 # 3. Install zig compiler, from ziglang.org
 RUN cd /opt && wget https://ziglang.org/download/0.7.0/zig-linux-x86_64-0.7.0.tar.xz\
@@ -22,7 +22,10 @@ RUN git clone https://github.com/polyml/polyml.git /tmp/polyml && cd /tmp/polyml
   && CFLAGS=-no-pie ./configure --prefix=/usr && make && make compiler && make install \
   && cd / && rm -rf /tmp/polyml
 
-# 5. Install all other compilers, from apt-get
+# 5. Tell apt to install node.js from nodesource.com, to get v15.x instead of v12.x
+RUN curl -sL https://deb.nodesource.com/setup_15.x | bash -
+
+# 6. Install all other compilers, from apt-get
 RUN apt-get update && apt-get install -yqq --no-install-recommends\
     default-jdk golang nodejs php-cli python3 ruby rustc \
   # Cleanup what we don't need

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-export DOCKER_TAG="jonasjso/adventofcode2020:2020-12-04-with-polyc-fix"
-
-
+export DOCKER_TAG="jonasjso/adventofcode2020:2020-12-05-with-node15"
 
 .PHONY:
 	test\

--- a/days/day-00-example/solutions/example.mjs
+++ b/days/day-00-example/solutions/example.mjs
@@ -1,7 +1,7 @@
-const fs = require("fs");
+import { readFileSync } from "fs";
 
 const STANDARD_IN = 0
-const lines = fs.readFileSync(STANDARD_IN).toString().split("\n").slice(0, -1)
+const lines = readFileSync(STANDARD_IN).toString().split("\n").slice(0, -1)
 
 let sumAll = 0;
 let sumOdd = 0;

--- a/days/day-00-example/test.sh
+++ b/days/day-00-example/test.sh
@@ -5,15 +5,15 @@ D=$(dirname $(realpath $0))
 
 echo ""
 echo "--- Day 0: Examples ---"
-$D/../../languages/c.sh      $D/input.txt $D/output.txt $D/solutions/example.c
 $D/../../languages/rust.sh   $D/input.txt $D/output.txt $D/solutions/example.rs
+$D/../../languages/go.sh     $D/input.txt $D/output.txt $D/solutions/example.go
+$D/../../languages/c.sh      $D/input.txt $D/output.txt $D/solutions/example.c
 $D/../../languages/cpp.sh    $D/input.txt $D/output.txt $D/solutions/example.cpp
 $D/../../languages/sml.sh    $D/input.txt $D/output.txt $D/solutions/example.sml
 $D/../../languages/bash.sh   $D/input.txt $D/output.txt $D/solutions/example.bash
 $D/../../languages/php.sh    $D/input.txt $D/output.txt $D/solutions/example.php
 $D/../../languages/python.sh $D/input.txt $D/output.txt $D/solutions/example.py
 $D/../../languages/ruby.sh   $D/input.txt $D/output.txt $D/solutions/example.rb
+$D/../../languages/node.sh   $D/input.txt $D/output.txt $D/solutions/example.mjs
 $D/../../languages/java.sh   $D/input.txt $D/output.txt $D/solutions Example
-$D/../../languages/node.sh   $D/input.txt $D/output.txt $D/solutions/example.js
-$D/../../languages/go.sh     $D/input.txt $D/output.txt $D/solutions/example.go
 echo ""

--- a/languages/node.sh
+++ b/languages/node.sh
@@ -2,14 +2,14 @@
 set -euo pipefail
 
 # Usage:   ./languages/node.sh INPUT                 OUTPUT                 SOLUTION
-# Example: ./languages/node.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.js
+# Example: ./languages/node.sh days/day-03/input.txt days/day-03/output.txt days/day-03/solutions/main.mjs
 
 INPUT="$1"
 OUTPUT="$2"
 SOLUTION="$3"
 
 start=$(($(date +%s%N)/1000000))
-cat $INPUT | node $SOLUTION | diff - $OUTPUT
+cat $INPUT | node --harmony-top-level-await $SOLUTION | diff - $OUTPUT
 end=$(($(date +%s%N)/1000000))
 
 TIME="$(expr $end - $start)"


### PR DESCRIPTION
**Why?**
- Because node 14 and 15 allows to write javascript with ES6 modules syntax. 

**node 12 legacy import**
https://github.com/Arxcis/adventofcode2020/blob/8d8a352e535bbd0ebeced12ffc1ea8242a2bdf20/days/day-00-example/solutions/example.js#L1-L4

**node 15 es6 import**
https://github.com/Arxcis/adventofcode2020/blob/210d616bd1f1787cc1f376157ca34e063c30f2bd/days/day-00-example/solutions/example.mjs#L1-L4

- Top-level async-await using `--harmony-top-level-await`
- Coalescing operator, and elvis operator `(??, ?.)`