### PR TITLE
Setting size of 4 spaces as for python configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,9 @@ insert_final_newline = true
 [*.java]
 indent_size = 4
 
+[*.py]
+indent_size = 4
+
 [Makefile]
 indent_style = tab
 indent_size = 4


### PR DESCRIPTION
A minor addition to .editorconfig to resolve this #48 