### PR TITLE
update zig: 0.7.1 -> 0.9nightly

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-export DOCKER_TAG="jonasjso/adventofcode2020:2021-12-04-with-kotlin-1.5.32-take3"
+export DOCKER_TAG="jonasjso/adventofcode2020:2021-12-07-with-zig-0.9-nightly"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update && apt-get install -yqq --no-install-recommends\
   build-essential git wget ca-certificates curl unzip
 
 # 3. Install zig compiler, from ziglang.org
-RUN cd /tmp && wget https://ziglang.org/download/0.7.1/zig-linux-x86_64-0.7.1.tar.xz\
-  && tar xf zig-linux-x86_64-0.7.1.tar.xz\
+RUN cd /tmp && wget https://ziglang.org/builds/zig-linux-x86_64-0.9.0-dev.1919+0812b5746.tar.xz
+  && tar xf zig-linux-x86_64-0.9.0-dev.1919+0812b5746.tar.xz\
   && mkdir -p /bin/lib\
-  && cp zig-linux-x86_64-0.7.1/zig /bin/\
-  && cp -ru zig-linux-x86_64-0.7.1/lib/* /bin/lib/\
+  && cp zig-linux-x86_64-0.9.0-dev.1919+0812b5746/zig /bin/\
+  && cp -ru zig-linux-x86_64-0.9.0-dev.1919+0812b5746/lib/* /bin/lib/\
   && chmod ugo+x /bin/zig\
   && rm -rf /tmp/*
 


### PR DESCRIPTION
Make sure not to update 2020 workflow in release.
See comment by @Arxcis: https://github.com/Arxcis/adventofcode2020/issues/126#issuecomment-987885271 