### PR TITLE
fix #135 by always printing title before test runs

### DIFF
--- a/2021/test.sh
+++ b/2021/test.sh
@@ -8,3 +8,4 @@ echo ""
 echo "------------------------ 2021 ------------------------"
 
 for DAY in $DAYS; do $DAY/test.sh; done
+

--- a/lang/bash.sh
+++ b/lang/bash.sh
@@ -12,14 +12,14 @@ IO_FILES=$2
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "bash" "$SOLUTION"
   START=$($D/time/start.sh)
-
-  # Pair-wise iteration
+ 
   while read INPUT OUTPUT; do
     cat $INPUT | bash $SOLUTION | diff - $OUTPUT
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "bash" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
+

--- a/lang/c.sh
+++ b/lang/c.sh
@@ -15,9 +15,10 @@ OUT="$(mktemp)"
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "gcc" "$SOLUTION"
+
   gcc $SOLUTION -o $OUT;
 
-  $D/print/start.sh "gcc" "$SOLUTION"
   START=$($D/time/start.sh)
 
   while read INPUT OUTPUT; do
@@ -25,7 +26,7 @@ do
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-  $D/print/stop.sh "$TIME" 
+  $D/print/stop.sh "$TIME"
 done
 
 rm $OUT;

--- a/lang/c.sh
+++ b/lang/c.sh
@@ -17,16 +17,16 @@ for SOLUTION in $SOLUTION_FILES
 do
   gcc $SOLUTION -o $OUT;
 
+  $D/print/start.sh "gcc" "$SOLUTION"
   START=$($D/time/start.sh)
 
-  # Pair-wise iteration
   while read INPUT OUTPUT; do
     cat $INPUT | $OUT | diff - $OUTPUT
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "gcc" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME" 
 done
 
 rm $OUT;
+

--- a/lang/cpp.sh
+++ b/lang/cpp.sh
@@ -15,9 +15,10 @@ OUT="$(mktemp)"
 
 for SOLUTION in $SOLUTION_FILES
 do
-  g++ $SOLUTION -o $OUT;
-
   $D/print/start.sh "g++" "$SOLUTION"
+
+  g++ $SOLUTION -o $OUT;
+  
   START=$($D/time/start.sh)
 
   while read INPUT OUTPUT; do

--- a/lang/cpp.sh
+++ b/lang/cpp.sh
@@ -17,15 +17,15 @@ for SOLUTION in $SOLUTION_FILES
 do
   g++ $SOLUTION -o $OUT;
 
+  $D/print/start.sh "g++" "$SOLUTION"
   START=$($D/time/start.sh)
 
-  # Pair-wise iteration
   while read INPUT OUTPUT; do
     cat $INPUT | $OUT | diff - $OUTPUT
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "g++" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
 rm $OUT;
+

--- a/lang/deno.sh
+++ b/lang/deno.sh
@@ -11,9 +11,10 @@ SOLUTION_FILES=$1
 IO_FILES=$2
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "deno" "$SOLUTION"
+  
   deno install -f --quiet "$SOLUTION" >/dev/null
 
-  $D/print/start.sh "deno" "$SOLUTION"
   START=$($D/time/start.sh)
 
   while read INPUT OUTPUT; do

--- a/lang/deno.sh
+++ b/lang/deno.sh
@@ -13,6 +13,7 @@ for SOLUTION in $SOLUTION_FILES
 do
   deno install -f --quiet "$SOLUTION" >/dev/null
 
+  $D/print/start.sh "deno" "$SOLUTION"
   START=$($D/time/start.sh)
 
   while read INPUT OUTPUT; do
@@ -20,6 +21,6 @@ do
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "deno" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
+

--- a/lang/go.sh
+++ b/lang/go.sh
@@ -17,16 +17,16 @@ for SOLUTION in $SOLUTION_FILES
 do
   go build -o $OUT $SOLUTION;
 
+  $D/print/start.sh "go" "$SOLUTION"
   START=$($D/time/start.sh)
 
-  # Pair-wise iteration
   while read INPUT OUTPUT; do
     cat $INPUT | $OUT | diff - $OUTPUT
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "go" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
 
 rm $OUT;
+

--- a/lang/go.sh
+++ b/lang/go.sh
@@ -15,9 +15,10 @@ OUT="$(mktemp)"
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "go" "$SOLUTION"
+
   go build -o $OUT $SOLUTION;
 
-  $D/print/start.sh "go" "$SOLUTION"
   START=$($D/time/start.sh)
 
   while read INPUT OUTPUT; do

--- a/lang/node.sh
+++ b/lang/node.sh
@@ -12,6 +12,7 @@ IO_FILES=$2
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "node" "$SOLUTION"
   START=$($D/time/start.sh)
 
   while read INPUT OUTPUT; do
@@ -19,6 +20,6 @@ do
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "node" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
+

--- a/lang/php.sh
+++ b/lang/php.sh
@@ -12,14 +12,14 @@ IO_FILES=$2
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "php" "$SOLUTION"
   START=$($D/time/start.sh)
 
-  # Pair-wise iteration
   while read INPUT OUTPUT; do
     cat $INPUT | php $SOLUTION | diff - $OUTPUT
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "php" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
+

--- a/lang/print/start.sh
+++ b/lang/print/start.sh
@@ -5,5 +5,5 @@ CMD="$1"
 FILE="$2"
 
 # %-23s is to accomodate for the longest known solution name: "one-liner.stektpotet.bash"
-printf "cat \$INPUT | %-8s %-23s" "$CMD" "$(basename -- $FILE)"
+printf "cat \$INPUT | %-8s %-23s | diff - \$OUTPUT --> " "$CMD" "$(basename -- $FILE)"
 

--- a/lang/print/start.sh
+++ b/lang/print/start.sh
@@ -5,5 +5,5 @@ CMD="$1"
 FILE="$2"
 
 # %-23s is to accomodate for the longest known solution name: "one-liner.stektpotet.bash"
-printf "cat \$INPUT | %-8s %-23s | diff - \$OUTPUT --> " "$CMD" "$(basename -- $FILE)"
+printf "cat \$INPUT | %-8s %-23s --> " "$CMD" "$(basename -- $FILE)"
 

--- a/lang/print/start.sh
+++ b/lang/print/start.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 
 CMD="$1"
-TIME="$2ms"
-FILE="$3"
+FILE="$2"
 
 # %-23s is to accomodate for the longest known solution name: "one-liner.stektpotet.bash"
-printf "cat \$INPUT | %-8s %-23s %-7s    ✅\n" "$CMD" "$(basename -- $FILE)" "$TIME"
+printf "cat \$INPUT | %-8s %-23s" "$CMD" "$(basename -- $FILE)"
+

--- a/lang/print/stop.sh
+++ b/lang/print/stop.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TIME="$1ms"
+
+printf "%-7s    ✅\n" "$TIME"
+

--- a/lang/python.sh
+++ b/lang/python.sh
@@ -12,14 +12,14 @@ IO_FILES=$2
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "python3" "$SOLUTION"
   START=$($D/time/start.sh)
 
-  # Pair-wise iteration
   while read INPUT OUTPUT; do
     cat $INPUT | python3 $SOLUTION | diff - $OUTPUT
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "python3" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
+

--- a/lang/ruby.sh
+++ b/lang/ruby.sh
@@ -12,6 +12,7 @@ IO_FILES=$2
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "ruby" "$SOLUTION"
   START=$($D/time/start.sh)
 
   while read INPUT OUTPUT; do
@@ -19,6 +20,5 @@ do
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "ruby" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done

--- a/lang/rust.sh
+++ b/lang/rust.sh
@@ -17,6 +17,7 @@ for SOLUTION in $SOLUTION_FILES
 do
   rustc $SOLUTION -o $OUT;
 
+  $D/print/start.sh "rustc" "$SOLUTION"
   START=$($D/time/start.sh)
 
   # Pair-wise iteration
@@ -25,8 +26,8 @@ do
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "rustc" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
 
 rm $OUT;
+

--- a/lang/rust.sh
+++ b/lang/rust.sh
@@ -15,9 +15,10 @@ OUT="$(mktemp)"
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "rustc" "$SOLUTION"
+
   rustc $SOLUTION -o $OUT;
 
-  $D/print/start.sh "rustc" "$SOLUTION"
   START=$($D/time/start.sh)
 
   # Pair-wise iteration

--- a/lang/sml.sh
+++ b/lang/sml.sh
@@ -23,6 +23,7 @@ do
 
   cd - >/dev/null
 
+  $D/print/start.sh "polyc" "$SOLUTION"
   START=$($D/time/start.sh)
 
   # Pair-wise iteration
@@ -32,5 +33,6 @@ do
 
   TIME=$($D/time/stop.sh $START)
 
-  $D/print/success.sh "polyc" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
+

--- a/lang/sml.sh
+++ b/lang/sml.sh
@@ -16,6 +16,7 @@ trap 'rm -f "$OUT"' EXIT
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "polyc" "$SOLUTION"
 
   cd $(dirname $(realpath $SOLUTION))
 
@@ -23,7 +24,6 @@ do
 
   cd - >/dev/null
 
-  $D/print/start.sh "polyc" "$SOLUTION"
   START=$($D/time/start.sh)
 
   # Pair-wise iteration

--- a/lang/zig.sh
+++ b/lang/zig.sh
@@ -15,6 +15,8 @@ OUT="$(mktemp)"
 
 for SOLUTION in $SOLUTION_FILES
 do
+  $D/print/start.sh "zig" "$SOLUTION"
+
   SOLUTION_NAME="zig_solution"
   TEMP_SOURCE="/tmp/$SOLUTION_NAME.zig"
   TEMP_BIN="/tmp/$SOLUTION_NAME"
@@ -26,7 +28,6 @@ do
   zig build-exe $TEMP_SOURCE --name $SOLUTION_NAME
   cd - >/dev/null
 
-  $D/print/start.sh "zig" "$SOLUTION"
   START=$($D/time/start.sh)
 
   # Pair-wise iteration

--- a/lang/zig.sh
+++ b/lang/zig.sh
@@ -26,6 +26,7 @@ do
   zig build-exe $TEMP_SOURCE --name $SOLUTION_NAME
   cd - >/dev/null
 
+  $D/print/start.sh "zig" "$SOLUTION"
   START=$($D/time/start.sh)
 
   # Pair-wise iteration
@@ -34,6 +35,6 @@ do
   done < <(echo $IO_FILES | xargs -n2)
 
   TIME=$($D/time/stop.sh $START)
-
-  $D/print/success.sh "zig" "$TIME" "$SOLUTION"
+  $D/print/stop.sh "$TIME"
 done
+


### PR DESCRIPTION
Fix #135

# Demo zig compiler error
```
--- Day 6: Custom customs ---
cat $INPUT | go       day06.stektpotet.go     --> 199ms      ✅
cat $INPUT | go       tholok97.go             --> 192ms      ✅
cat $INPUT | gcc      day06.c                 --> 154ms      ✅
cat $INPUT | zig      day06.zig               --> ./zig_solution.zig:64:29: error: expected type 'type', found '[]u8'
    var it = mem.split(bytes[0..length], "\n\n");
```
You can see that `day06.zig` does not have `--> \d+ms ✅` at the end. This indicates that `day06.zig` was not able to pass the test.

This new behaviour should be expected for both compiler and runtime errors.